### PR TITLE
Remove use of Windows jobs in juicify to avoid errors

### DIFF
--- a/cmd/juicify/app/juicify_windows.go
+++ b/cmd/juicify/app/juicify_windows.go
@@ -7,7 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/kolesnikovae/go-winjob"
+	// See https://github.com/Juice-Labs/juice/issues/1765.
+	// "github.com/kolesnikovae/go-winjob"
 
 	"github.com/Juice-Labs/Juice-Labs/pkg/task"
 )
@@ -21,33 +22,43 @@ func createCommand(args []string) *exec.Cmd {
 }
 
 func runCommand(group task.Group, cmd *exec.Cmd, config Configuration) error {
-	job, err := winjob.Create("Juicify", winjob.WithKillOnJobClose())
-	if err != nil {
-		return err
-	}
-	defer job.Close()
+	// Windows jobs intermittently generate "SetInformationJobOject: The
+	// parameter is incorrect" errors when trying to execute launch.exe to
+	// spawn and inject Juice into an application.  Also juicify doesn't exit
+	// when the launched process exits when using Windows jobs.
+	//
+	// Commented out for now to preserve existing behavior from the C++
+	// version of juicify.  See https://github.com/Juice-Labs/juice/issues/1756
+	// and https://github.com/Juice-Labs/juice/issues/1765.
+	//
+	// job, err := winjob.Create("Juicify", winjob.WithKillOnJobClose())
+	// if err != nil {
+	// 	return err
+	// }
+	// defer job.Close()
 
-	notificationChannel := make(chan winjob.Notification, 1)
-	subscription, err := winjob.Notify(notificationChannel, job)
-	if err != nil {
-		return err
-	}
-	defer subscription.Close()
+	// notificationChannel := make(chan winjob.Notification, 1)
+	// subscription, err := winjob.Notify(notificationChannel, job)
+	// if err != nil {
+	// 	return err
+	// }
+	// defer subscription.Close()
 
-	err = winjob.StartInJobObject(cmd, job)
-	if err != nil {
-		return err
-	}
+	// err = winjob.StartInJobObject(cmd, job)
+	// if err != nil {
+	// 	return err
+	// }
 
-	for {
-		select {
-		case <-group.Ctx().Done():
-			return nil
+	// for {
+	// 	select {
+	// 	case <-group.Ctx().Done():
+	// 		return nil
 
-		case n := <-notificationChannel:
-			if n.Type == winjob.NotificationActiveProcessZero {
-				return nil
-			}
-		}
-	}
+	// 	case n := <-notificationChannel:
+	// 		if n.Type == winjob.NotificationActiveProcessZero {
+	// 			return nil
+	// 		}
+	// 	}
+	// }
+	return cmd.Run()
 }


### PR DESCRIPTION
Windows jobs intermittently generate "SetInformationJobOject: The parameter is incorrect" errors when trying to execute launch.exe to spawn and inject Juice into an application and juicify doesn't exit when the launched process exits.

Fixes #1756.