### PR TITLE
CORS fix

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	port int
 
 	root      *mux.Router
+	handler   http.Handler
 	tlsConfig *tls.Config
 
 	endpoints []Endpoint
@@ -81,12 +82,14 @@ func NewServer(address string, tlsConfig *tls.Config) (*Server, error) {
 	})
 
 	root := mux.NewRouter().StrictSlash(true)
-	root.Use(logger.Middleware, cors.Handler)
+	root.Use(logger.Middleware)
+	handler := cors.Handler(root)
 
 	server := &Server{
 		url:       url,
 		port:      port,
 		root:      root,
+		handler:   handler,
 		tlsConfig: tlsConfig,
 	}
 
@@ -164,7 +167,7 @@ func (server *Server) Run(group task.Group) error {
 			return group.Ctx()
 		},
 		Addr:      server.url.Host,
-		Handler:   server.root,
+		Handler:   server.handler,
 		TLSConfig: server.tlsConfig,
 	}
 


### PR DESCRIPTION
The CORS handler needs to wrap the router handler (rather than the other way around) in order to correctly respond to HTTP preflight OPTIONS requests.